### PR TITLE
Fix errors in the build-image action

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -3,7 +3,7 @@ name: Build and push image
 on:
   pull_request:
     paths:
-      - .github/workflows/push-image.yml
+      - .github/workflows/build-image.yml
       - Dockerfile
   push:
     branches:
@@ -17,12 +17,17 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ toLower(github.repository) }}
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -24,24 +24,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version: v1.24.5
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Login to GHCR
         if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -49,7 +49,7 @@ jobs:
 
       - name: Generate image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         with:
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -62,7 +62,7 @@ jobs:
         run: 'make build'
 
       - name: Build and push image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -28,6 +28,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: v1.24.5
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -53,7 +58,10 @@ jobs:
             type=ref,event=tag
             type=sha
 
-      - name: Build and push
+      - name: Build project
+        run: 'make build'
+
+      - name: Build and push image
         uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
Follow up on #3 to fix a couple of errors:

- Fix a path name for triggering the action run on PRs
- Add a checkout step to make sure the repository is cloned
- Add a build step as the image build process requires binaries to be already present
- Remove non-existing `toLower` function (our org and repository names are anyways lower cases)
- All GitHub Actions specified in `uses` are now pinned to SHAs

/assign @xrstf @embik 