### PR TITLE
Implement required patches for kcp

### DIFF
--- a/artifacts/scripts/util.sh
+++ b/artifacts/scripts/util.sh
@@ -171,7 +171,7 @@ sync_repo() {
     local f_mainline_commits=""
     if [ "${new_branch}" = "true" ] && [ "${src_branch}" = "${git_default_branch}" ]; then
         # new master branch
-        filter-branch "${commit_msg_tag}" "${subdirectories}" "${recursive_delete_pattern}" ${src_branch} filtered-branch
+        filter-branch "${commit_msg_tag}" "${subdirectories}" "${recursive_delete_pattern}" "upstream/${src_branch}" filtered-branch
 
         # find commits on the main line (will mostly be merges, but could be non-merges if filter-branch dropped
         # the corresponding fast-forward merge and left the feature branch commits)

--- a/cmd/publishing-bot/config/rules.go
+++ b/cmd/publishing-bot/config/rules.go
@@ -73,6 +73,8 @@ type BranchRule struct {
 type RepositoryRule struct {
 	DestinationRepository string       `yaml:"destination"`
 	Branches              []BranchRule `yaml:"branches"`
+	// the value to use as vX in vX.Y.Z published at the destination repo
+	DestinationTagBase string `yaml:"destination-tag-base,omitempty"`
 	// SmokeTest applies to all branches
 	SmokeTest string `yaml:"smoke-test,omitempty"` // a multiline bash script
 	Library   bool   `yaml:"library,omitempty"`
@@ -81,10 +83,13 @@ type RepositoryRule struct {
 }
 
 type RepositoryRules struct {
-	SkippedSourceBranches []string         `yaml:"skip-source-branches,omitempty"`
-	SkipGomod             bool             `yaml:"skip-gomod,omitempty"`
-	SkipTags              bool             `yaml:"skip-tags,omitempty"`
-	Rules                 []RepositoryRule `yaml:"rules"`
+	SkippedSourceBranches []string `yaml:"skip-source-branches,omitempty"`
+	SkipGomod             bool     `yaml:"skip-gomod,omitempty"`
+	SkipTags              bool     `yaml:"skip-tags,omitempty"`
+	// this skips tags in the source repo that are not valid semver tags
+	// e.g. v1.2.3 is valid, but <prefix>/v1.2.3 is not valid.
+	SkipNonSemverTags bool             `yaml:"skip-non-semver-tags,omitempty"`
+	Rules             []RepositoryRule `yaml:"rules"`
 
 	// ls-files patterns like: */BUILD *.ext pkg/foo.go Makefile
 	RecursiveDeletePatterns []string `yaml:"recursive-delete-patterns"`

--- a/cmd/publishing-bot/publisher.go
+++ b/cmd/publishing-bot/publisher.go
@@ -292,6 +292,12 @@ func (p *PublisherMunger) construct() error {
 				p.plog.Infof("synchronizing tags is disabled")
 			}
 
+			skipNonSemverTags := "false"
+			if p.reposRules.SkipNonSemverTags {
+				skipNonSemverTags = "true"
+				p.plog.Infof("synchronizing non-semver tags is disabled")
+			}
+
 			// get old published hash to eventually skip cherry picking
 			var lastPublishedUpstreamHash string
 			bs, err := os.ReadFile(path.Join(p.baseRepoPath, publishedFileName(repoRule.DestinationRepository, branchRule.Name)))
@@ -318,6 +324,8 @@ func (p *PublisherMunger) construct() error {
 				strconv.FormatBool(repoRule.Library),
 				strings.Join(p.reposRules.RecursiveDeletePatterns, " "),
 				skipTags,
+				skipNonSemverTags,
+				repoRule.DestinationTagBase,
 				lastPublishedUpstreamHash,
 				p.config.GitDefaultBranch,
 			)

--- a/pkg/golang/install.go
+++ b/pkg/golang/install.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/golang/glog"
@@ -95,7 +96,7 @@ func installGoVersion(v, pth string) error {
 	}
 	defer os.RemoveAll(tmpPath)
 
-	cmd := exec.Command("/bin/bash", "-c", fmt.Sprintf("curl -SLf https://storage.googleapis.com/golang/go%s.linux-amd64.tar.gz | tar -xz --strip 1 -C %s", v, tmpPath))
+	cmd := exec.Command("/bin/bash", "-c", fmt.Sprintf("curl -SLf https://storage.googleapis.com/golang/go%s.%s-%s.tar.gz | tar -xz --strip 1 -C %s", v, runtime.GOOS, runtime.GOARCH, tmpPath))
 	cmd.Dir = tmpPath
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
This PR implements some required patches to make the publishing-bot work for kcp:

- Fix git command failing due to missing remote (already tested)
- Add two new options to allow better control over tags (`skip-non-semver-tags` and `destination-tag-base`)
- Add support for ARM64

Speaking of tags, the upstream publishing-bot always pushes two tags: `<source-repo-name>-<source-tag-name>` and `<tag-name>` (if `--publish-v0-semver` flag is set in `artifacts/scripts/construct.sh`).

However, publishing-bot constructs `<tag-name>` with v0 major regardless of the major version of the source tag. But even if that wasn't the case, our source repo (`kcp-dev/kcp`) is at v0 major, while staged repositories (`apimachinery` and `code-generator` to be precise) are at v2 and v3 major. For those affected staged repositories, we can't push a tag with v0 major, because the Go module is also at v2 and v3, respectively.

Instead, we'll push tags that are v2 major and v3 major for those repositories, and these two new options will allow us to do that. For example, when we push v0.29.0 to `kcp-dev/kcp`, publishing-bot will push v2.29.0 to `kcp-dev/apimachinery` and v3.29.0 to `kcp-dev/code-generator`.

/assign @xrstf @embik 